### PR TITLE
Remove stray HTML closing tags

### DIFF
--- a/script.js
+++ b/script.js
@@ -454,6 +454,3 @@ window.onload = () => {
     setupEventListeners();
     renderSlide(currentSlideId);
 };
-    </script>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- clean up script.js by removing leftover HTML closing tags so the file contains only JavaScript code

## Testing
- `node -c script.js` *(fails silently as Node has no compile-only option, but ran without syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868eaa1f2988321b8e39e37719c2da1