### PR TITLE
Fix initial blank screen issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -452,8 +452,3 @@ async function showVideoModal(slide) {
 DOM.videoCloseBtn.onclick = () => {
     DOM.videoModal.classList.add('hidden');
 };
-
-window.onload = () => {
-    setupEventListeners();
-    renderSlide(currentSlideId);
-};


### PR DESCRIPTION
## Summary
- remove redundant `window.onload` assignment using undefined `currentSlideId`

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6868ed1f255c83219e5f1391f355367d