### PR TITLE
Fix question generation fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,6 @@ Adicionar Novos Desafios: Para adicionar um novo desafio, crie um novo objeto de
 Adicionar Novos Blocos ou Capítulos: Siga a estrutura dos objetos isHub:!0 para criar novos painéis de missão e conecte-os através da propriedade nextChapterSlide.
 
 Fim da transmissão.
+
+6. Solução de Problemas
+Se nenhum desafio for gerado e apenas o texto do slide aparecer, verifique a implantação da função `gemini-proxy` no Supabase e confirme que o segredo `GOOGLE_API_KEY` está definido corretamente. Erros de autenticação com a API do Google impedem a criação das questões e o jogo exibirá somente o conteúdo estático.

--- a/script.js
+++ b/script.js
@@ -355,6 +355,25 @@ async function renderDiagnosis(slide, difficulty) {
         extraHelpContainer.appendChild(enemButton);
         extraHelpContainer.appendChild(videoButton);
         DOM.choicesContainer.appendChild(extraHelpContainer);
+    } else {
+        const textEl = DOM.textContainer.querySelector('.text-gray-300');
+        if (textEl && dynamicSlide.text) {
+            textEl.innerHTML = dynamicSlide.text;
+        }
+
+        if (dynamicSlide.question) {
+            const questionContainer = document.createElement('div');
+            questionContainer.className = 'mt-6';
+            questionContainer.innerHTML = `<p class='font-bold text-red-400 text-lg'>${dynamicSlide.question}</p>`;
+            DOM.textContainer.appendChild(questionContainer);
+        }
+
+        if (dynamicSlide.choices) {
+            dynamicSlide.choices.forEach(choice => {
+                const button = createButton(choice.text, () => renderSlide(choice.nextSlide), 'justify-center bg-indigo-700 hover:bg-indigo-600 text-gray-100 border-indigo-900', false, 'Avançar na história.');
+                DOM.choicesContainer.appendChild(button);
+            });
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show fallback text when Gemini fails to generate a question
- document troubleshooting steps for missing GOOGLE_API_KEY in Supabase

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6868ef96e5e88321a1c003e017c0d50d